### PR TITLE
Deprecate the 9.1 enterprise appliance for the ownCloud X version

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -58,10 +58,9 @@ This documents the *previous stable* release of ownCloud.
 Enterprise Appliance
 ====================
 
-The Enterprise 9.0 Appliance is a complete virtual machine image running ownCloud 9
-Enterprise on Ubuntu Linux.
+The ownCloud X Enterprise Appliance is a complete virtual machine image running ownCloud X Enterprise on Ubuntu Linux.
 
-* `Enterprise Appliance Manual <https://doc.owncloud.com/appliance/>`_
+* `ownCloud X Enterprise Appliance Manual <https://doc.owncloud.org/server/10.0/admin_manual/enterprise/appliance/index.html>`_
 
 ==============================
 Desktop Client and Mobile Apps


### PR DESCRIPTION
This fixes https://github.com/owncloud/documentation/issues/3114.