### PR TITLE
Replace example link with real one

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -22,7 +22,7 @@ reports and contributions. Please see :doc:`howto_contribute` for instructions.
 Current Stable Server Release
 -----------------------------
 
-The administrator, user, and developer manuals for the current stable release are always at https ://doc.owncloud.org/server/latest/[manual].
+The administrator, user, and developer manuals for the current stable release are always at https://doc.owncloud.org/#current-stable-server-release.
 
 ----------------------------------------
 Latest Stable Release  - ownCloud 10.0


### PR DESCRIPTION
This PR replaces the existing manuals link guide with a working link.

### Relates To

https://github.com/owncloud/documentation/issues/3286